### PR TITLE
Update for Laravel 5.2 and legacy compactibility

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -41,7 +41,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 	 */
 	public function register()
 	{
-		$this->app->bindShared('MyBB\Settings\Manager', function (Application $app) {
+		$this->app->singleton('MyBB\Settings\Manager', function (Application $app) {
 
 			return new Manager($app);
 		});


### PR DESCRIPTION
Changing bindShared as it's deprecated in 5.1 and removed from 5.2.